### PR TITLE
Better header

### DIFF
--- a/style.css
+++ b/style.css
@@ -9,7 +9,8 @@ body {
   background-color: white;
   flex-direction: row;
   align-items: center;
-  position:fixed;top: 10px;
+  position:fixed;
+  top: 10px;
 }
 
 .barra-statica a {

--- a/style.css
+++ b/style.css
@@ -11,6 +11,7 @@ body {
   align-items: center;
   position:fixed;
   top: 10px;
+  left: 0;
 }
 
 .barra-statica a {


### PR DESCRIPTION
In `.barra-statica` hai usato il `position: fixed;` e hai dato `top: 10px;`.

Quando usi `position: fixed;` (ma vale anche nel caso di `absolute`) attento a valorizzare correttamente anche l'altra impostazione di posizionamento.

Se imposti `top`, allora devi impostare anche `left` oppure `right` e viceversa, se imposti, ad esempio, `right`, allora devi impostare anche `top` o `bottom`, altrimenti i valori delle impostazioni "complementari" possono assumere dei valori predefiniti.
